### PR TITLE
Rename maxBatchSize into maxBatchLogEvents

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ A real life `logback.xml` would probably look like this (when all options are sp
         <!-- So even when running inside an AWS instance in us-west-1, logs will go to us-west-2 -->
         <logRegion>us-west-2</logRegion>
         
-        <!-- Maximum number of event in each batch (50 is the default) -->
+        <!-- Maximum number of events in each batch (50 is the default) -->
         <!-- will flush when the event queue has 50 elements, even if still in quiet time (see maxFlushTimeMillis) -->
-        <maxBatchSize>50</maxBatchSize>
+        <maxBatchLogEvents>50</maxBatchLogEvents>
         
         <!-- Maximum quiet time in millisecond (0 is the default) -->
         <!-- will flush when met, even if the batch size is not met (see maxBatchSize) -->

--- a/src/main/java/ca/pjer/logback/AwsLogsAppender.java
+++ b/src/main/java/ca/pjer/logback/AwsLogsAppender.java
@@ -16,7 +16,7 @@ public class AwsLogsAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     private String logGroupName;
     private String logStreamName;
     private String logRegion;
-    private int maxBatchSize = 50;
+    private int maxBatchLogEvents = 50;
     private long maxFlushTimeMillis = 0;
     private long maxBlockTimeMillis = 5000;
 
@@ -64,13 +64,13 @@ public class AwsLogsAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     }
 
     @SuppressWarnings({"unused", "WeakerAccess"})
-    public int getMaxBatchSize() {
-        return maxBatchSize;
+    public int getMaxBatchLogEvents() {
+        return maxBatchLogEvents;
     }
 
     @SuppressWarnings({"unused", "WeakerAccess"})
-    public void setMaxBatchSize(int maxQueueSize) {
-        this.maxBatchSize = maxQueueSize;
+    public void setMaxBatchLogEvents(int maxBatchLogEvents) {
+        this.maxBatchLogEvents = maxBatchLogEvents;
     }
 
     @SuppressWarnings({"unused", "WeakerAccess"})

--- a/src/test/java/ca/pjer/logback/AsyncWorkerTest.java
+++ b/src/test/java/ca/pjer/logback/AsyncWorkerTest.java
@@ -29,12 +29,12 @@ public class AsyncWorkerTest {
         return event;
     }
 
-    private static AsyncWorker asyncWorker(AWSLogsStub mockedAwsLogsStub, int maxBatchSize, long maxFlushTimeMillis, long maxBlockTimeMillis) {
+    private static AsyncWorker asyncWorker(AWSLogsStub mockedAwsLogsStub, int maxBatchLogEvents, long maxFlushTimeMillis, long maxBlockTimeMillis) {
         AwsLogsAppender awsLogsAppender = new AwsLogsAppender();
         awsLogsAppender.setLayout(new EchoLayout<ILoggingEvent>());
         awsLogsAppender.setLogGroupName("FakeGroup");
         awsLogsAppender.setLogStreamName("FakeStream");
-        awsLogsAppender.setMaxBatchSize(maxBatchSize);
+        awsLogsAppender.setMaxBatchLogEvents(maxBatchLogEvents);
         awsLogsAppender.setMaxFlushTimeMillis(maxFlushTimeMillis);
         awsLogsAppender.setMaxBlockTimeMillis(maxBlockTimeMillis);
         awsLogsAppender.setAwsLogsStub(mockedAwsLogsStub);


### PR DESCRIPTION
Amazon uses "maximum batch size" for measuring the size of a batch in
bytes. We used it for the number of events in the log. This commit
changes the name to be more consistent with Amazon's documentation.

See also: #8
See also: http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html