### PR TITLE
Add support for logback-access

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,27 @@ A real life `logback.xml` would probably look like this (when all options are sp
 ```
 
 See [The logback manual - Chapter 3: Logback configuration](http://logback.qos.ch/manual/configuration.html) for more config options.
+
+## Logback-access support
+
+To use the appender with [Logback-access](https://logback.qos.ch/access.html) the layout class needs to be explicitly specified, 
+otherwise logback-access can't figure it out, and the default EchoLayout is used. Logback-access uses it's own, http-specific version
+of [PatternLayout](https://logback.qos.ch/access.html#configuration). 
+
+For example:
+
+```xml
+<configuration>
+
+    <appender name="AWS_LOGS" class="ca.pjer.logback.AwsLogsAppender">
+        <layout class="ch.qos.logback.access.PatternLayout">
+            <pattern>%h %l %u [%t{ISO8601}] "%r" %s %b "%i{Referer}" "%i{User-Agent}"</pattern>
+        </layout>
+    </appender>
+
+    <root>
+        <appender-ref ref="AWS_LOGS"/>
+    </root>
+
+</configuration>
+```

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,12 @@
             <version>1.1.7</version>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-access</artifactId>
+            <version>1.2.3</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-logs</artifactId>
             <version>1.11.423</version>
@@ -72,6 +78,12 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.2.17</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>4.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/ca/pjer/logback/AWSLogsStub.java
+++ b/src/main/java/ca/pjer/logback/AWSLogsStub.java
@@ -26,7 +26,6 @@ class AWSLogsStub {
 
     private AWSLogs awsLogs() {
         return lazyAwsLogs.getOrCompute(() -> {
-            System.out.println("Creating AWSLogs Client");
             AWSLogsClientBuilder builder = AWSLogsClientBuilder.standard();
             Optional.ofNullable(logRegion).ifPresent(builder::setRegion);
 

--- a/src/main/java/ca/pjer/logback/SyncWorker.java
+++ b/src/main/java/ca/pjer/logback/SyncWorker.java
@@ -1,17 +1,15 @@
 package ca.pjer.logback;
 
-import ch.qos.logback.classic.spi.ILoggingEvent;
-
 import java.util.Collections;
 
-class SyncWorker extends Worker {
+class SyncWorker<E> extends Worker<E> {
 
-    SyncWorker(AwsLogsAppender awsLogsAppender) {
+    SyncWorker(AwsLogsAppender<E> awsLogsAppender) {
         super(awsLogsAppender);
     }
 
     @Override
-    public synchronized void append(ILoggingEvent event) {
+    public synchronized void append(E event) {
         getAwsLogsAppender().getAwsLogsStub().logEvents(Collections.singleton(asInputLogEvent(event)));
     }
 }

--- a/src/test/java/ca/pjer/logback/AsyncWorkerAccessTest.java
+++ b/src/test/java/ca/pjer/logback/AsyncWorkerAccessTest.java
@@ -1,0 +1,55 @@
+package ca.pjer.logback;
+
+import ch.qos.logback.access.spi.AccessEvent;
+import ch.qos.logback.access.spi.IAccessEvent;
+import ch.qos.logback.access.spi.ServerAdapter;
+import ch.qos.logback.core.layout.EchoLayout;
+import com.amazonaws.services.logs.model.InputLogEvent;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Collection;
+
+import static org.mockito.Mockito.anyCollection;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class AsyncWorkerAccessTest {
+
+    private static Collection<InputLogEvent> anyInputLogEvents() {
+        return anyCollection();
+    }
+
+    private HttpServletRequest request = mock(HttpServletRequest.class);
+    private HttpServletResponse response = mock(HttpServletResponse.class);
+    private ServerAdapter serverAdapter = mock(ServerAdapter.class);
+
+    private static AsyncWorker<IAccessEvent> asyncWorker(AWSLogsStub mockedAwsLogsStub) {
+        AwsLogsAppender<IAccessEvent> awsLogsAppender = new AwsLogsAppender<>();
+        awsLogsAppender.setLayout(new EchoLayout<>());
+        awsLogsAppender.setLogGroupName("FakeGroup");
+        awsLogsAppender.setLogStreamName("FakeStream");
+        awsLogsAppender.setMaxBatchLogEvents(1);
+        awsLogsAppender.setMaxFlushTimeMillis(1);
+        awsLogsAppender.setMaxBlockTimeMillis(5000);
+        awsLogsAppender.setAwsLogsStub(mockedAwsLogsStub);
+        AsyncWorker<IAccessEvent> asyncWorker = new AsyncWorker<>(awsLogsAppender);
+        awsLogsAppender.setWorker(asyncWorker);
+        return asyncWorker;
+    }
+
+    @Test
+    public void testShouldLogWhenStarted() {
+        AWSLogsStub mockedAwsLogsStub = mock(AWSLogsStub.class);
+        IAccessEvent event = spy(new AccessEvent(request, response, serverAdapter));
+        AsyncWorker<IAccessEvent> asyncWorker = asyncWorker(mockedAwsLogsStub);
+        asyncWorker.start();
+        asyncWorker.append(event);
+        asyncWorker.stop();
+
+        verify(event).getTimeStamp();
+        verify(mockedAwsLogsStub).logEvents(anyInputLogEvents());
+    }
+}

--- a/src/test/java/ca/pjer/logback/AsyncWorkerTest.java
+++ b/src/test/java/ca/pjer/logback/AsyncWorkerTest.java
@@ -29,16 +29,16 @@ public class AsyncWorkerTest {
         return event;
     }
 
-    private static AsyncWorker asyncWorker(AWSLogsStub mockedAwsLogsStub, int maxBatchLogEvents, long maxFlushTimeMillis, long maxBlockTimeMillis) {
-        AwsLogsAppender awsLogsAppender = new AwsLogsAppender();
-        awsLogsAppender.setLayout(new EchoLayout<ILoggingEvent>());
+    private static AsyncWorker<ILoggingEvent> asyncWorker(AWSLogsStub mockedAwsLogsStub, int maxBatchLogEvents, long maxFlushTimeMillis, long maxBlockTimeMillis) {
+        AwsLogsAppender<ILoggingEvent> awsLogsAppender = new AwsLogsAppender<>();
+        awsLogsAppender.setLayout(new EchoLayout<>());
         awsLogsAppender.setLogGroupName("FakeGroup");
         awsLogsAppender.setLogStreamName("FakeStream");
         awsLogsAppender.setMaxBatchLogEvents(maxBatchLogEvents);
         awsLogsAppender.setMaxFlushTimeMillis(maxFlushTimeMillis);
         awsLogsAppender.setMaxBlockTimeMillis(maxBlockTimeMillis);
         awsLogsAppender.setAwsLogsStub(mockedAwsLogsStub);
-        AsyncWorker asyncWorker = new AsyncWorker(awsLogsAppender);
+        AsyncWorker<ILoggingEvent> asyncWorker = new AsyncWorker<>(awsLogsAppender);
         awsLogsAppender.setWorker(asyncWorker);
         return asyncWorker;
     }
@@ -46,7 +46,7 @@ public class AsyncWorkerTest {
     @Test
     public void testShouldNotLogWhenStopped() {
         AWSLogsStub mockedAwsLogsStub = mock(AWSLogsStub.class);
-        AsyncWorker asyncWorker = asyncWorker(mockedAwsLogsStub, 1, 1, 5000);
+        AsyncWorker<ILoggingEvent> asyncWorker = asyncWorker(mockedAwsLogsStub, 1, 1, 5000);
         asyncWorker.start();
         asyncWorker.stop();
         asyncWorker.append(dummyEvent());
@@ -56,7 +56,7 @@ public class AsyncWorkerTest {
     @Test
     public void testShouldLogWhenStarted() {
         AWSLogsStub mockedAwsLogsStub = mock(AWSLogsStub.class);
-        AsyncWorker asyncWorker = asyncWorker(mockedAwsLogsStub, 1, 1, 5000);
+        AsyncWorker<ILoggingEvent> asyncWorker = asyncWorker(mockedAwsLogsStub, 1, 1, 5000);
         asyncWorker.start();
         asyncWorker.append(dummyEvent());
         asyncWorker.stop();
@@ -66,7 +66,7 @@ public class AsyncWorkerTest {
     @Test
     public void testShouldLogAfterMaxBatchSize() {
         AWSLogsStub mockedAwsLogsStub = mock(AWSLogsStub.class);
-        AsyncWorker asyncWorker = asyncWorker(mockedAwsLogsStub, 5, Long.MAX_VALUE, 5000);
+        AsyncWorker<ILoggingEvent> asyncWorker = asyncWorker(mockedAwsLogsStub, 5, Long.MAX_VALUE, 5000);
         asyncWorker.start();
         asyncWorker.append(dummyEvent());
         asyncWorker.append(dummyEvent());
@@ -94,7 +94,7 @@ public class AsyncWorkerTest {
     @Test
     public void testShouldLogAfterMaxFlushTimeMillis() {
         AWSLogsStub mockedAwsLogsStub = mock(AWSLogsStub.class);
-        AsyncWorker asyncWorker = asyncWorker(mockedAwsLogsStub, 5, 1000, 5000);
+        AsyncWorker<ILoggingEvent> asyncWorker = asyncWorker(mockedAwsLogsStub, 5, 1000, 5000);
         asyncWorker.start();
         asyncWorker.append(dummyEvent());
         verify(mockedAwsLogsStub, after(1500)).logEvents(anyInputLogEvents());

--- a/src/test/java/ca/pjer/logback/WorkerTest.java
+++ b/src/test/java/ca/pjer/logback/WorkerTest.java
@@ -27,13 +27,13 @@ public class WorkerTest {
     private static final Layout<ILoggingEvent> LAYOUT = new EchoLayout<ILoggingEvent>();
     private static final int LAYOUT_OFFSET = LAYOUT.doLayout(asEvent("")).length();
     private static final int MESSAGE_SIZE_LIMIT = 262144 - 26 - LAYOUT_OFFSET;
-    private Worker worker;
+    private Worker<ILoggingEvent> worker;
 
     @Before
     public void setWorker() {
-        AwsLogsAppender awsLogsAppender = new AwsLogsAppender();
+        AwsLogsAppender<ILoggingEvent> awsLogsAppender = new AwsLogsAppender<>();
         awsLogsAppender.setLayout(LAYOUT);
-        worker = new SyncWorker(awsLogsAppender);
+        worker = new SyncWorker<>(awsLogsAppender);
     }
 
     @DataPoints("UNTRIMMED")
@@ -46,7 +46,7 @@ public class WorkerTest {
         InputLogEvent event = worker.asInputLogEvent(asEvent(message));
         assertFalse(event.getMessage().endsWith("..."));
     }
-    
+
     @DataPoints("TRIMMED")
     public static final String[] TRIMMED = {
             repeat("x", MESSAGE_SIZE_LIMIT + 1),
@@ -60,7 +60,7 @@ public class WorkerTest {
         InputLogEvent event = worker.asInputLogEvent(asEvent(message));
         assertTrue(event.getMessage().endsWith("..."));
     }
-    
+
     @DataPoints("TRIMMED_MB")
     public static final String[] TRIMMED_MB = {
             repeat("x", MESSAGE_SIZE_LIMIT - 9) + "öööööööööö",


### PR DESCRIPTION
I needed to write access log from Spring Boot to AWS, so I extended awslogs-appender to support logback-access (https://logback.qos.ch/access.html). It is working well now in my project, and I thought that maybe you'd like to check if this is something you could also use.

Basically, I generalized all the classes and interfaces so that they'll accept also `IAccessEvents` (actually, any kind of logging events). The logback-access-dependency is added as optional, so it doesn't get pulled in if not needed. 

For configuration, the layout-element requires an explicit layout-class, otherwise logback-access can't figure out what to use:
```xml
<layout class="ch.qos.logback.access.PatternLayout">
    <pattern>%h %l %u [%t{ISO8601}] "%r" %s %b "%i{Referer}" "%i{User-Agent}"</pattern>
</layout>
```