### PR TITLE
Upgrade to AWS SDK v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,9 @@
             <version>1.2.3</version>
         </dependency>
         <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-logs</artifactId>
-            <version>1.11.423</version>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>cloudwatchlogs</artifactId>
+            <version>2.16.65</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.2.17</version>
+            <version>3.10.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/ca/pjer/logback/AWSLogsStub.java
+++ b/src/main/java/ca/pjer/logback/AWSLogsStub.java
@@ -111,19 +111,20 @@ class AWSLogsStub {
             events = sortedEvents;
         }
 
+        ArrayList<InputLogEvent> correctedEvents = new ArrayList<InputLogEvent>(events.size());
         for (InputLogEvent event : events) {
             if (lastTimestamp != null && event.timestamp() < lastTimestamp) {
-                events.remove(event);
-                events.add(event.toBuilder()
+                correctedEvents.add(event.toBuilder()
                     .timestamp(lastTimestamp)
                     .build());
             } else {
+                correctedEvents.add(event);
                 lastTimestamp = event.timestamp();
             }
         }
-        AwsLogsMetricsHolder.get().incrementLogEvents(events.size());
+        AwsLogsMetricsHolder.get().incrementLogEvents(correctedEvents.size());
         AwsLogsMetricsHolder.get().incrementPutLog();
-        logPreparedEvents(events);
+        logPreparedEvents(correctedEvents);
     }
 
     private void logPreparedEvents(Collection<InputLogEvent> events) {

--- a/src/main/java/ca/pjer/logback/AsyncWorker.java
+++ b/src/main/java/ca/pjer/logback/AsyncWorker.java
@@ -12,10 +12,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import ca.pjer.logback.metrics.AwsLogsMetricsHolder;
-import com.amazonaws.services.logs.model.InputLogEvent;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
 
 class AsyncWorker extends Worker implements Runnable {
 

--- a/src/main/java/ca/pjer/logback/Worker.java
+++ b/src/main/java/ca/pjer/logback/Worker.java
@@ -1,10 +1,10 @@
 package ca.pjer.logback;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
 
 import java.nio.charset.Charset;
 
-import com.amazonaws.services.logs.model.InputLogEvent;
 
 abstract class Worker {
 
@@ -30,16 +30,18 @@ abstract class Worker {
     private static final int MAX_EVENT_SIZE = 262144;
 
     InputLogEvent asInputLogEvent(ILoggingEvent event) {
-        InputLogEvent inputLogEvent = new InputLogEvent().withTimestamp(event.getTimeStamp())
-                .withMessage(awsLogsAppender.encode(event));
+        String message = awsLogsAppender.encode(event);
 
-        if (eventSize(inputLogEvent) > MAX_EVENT_SIZE) {
+        if (eventSize(message) > MAX_EVENT_SIZE) {
             awsLogsAppender
                     .addWarn(String.format("Log message exceeded Cloudwatch Log's limit of %d bytes", MAX_EVENT_SIZE));
-            trimMessage(inputLogEvent, MAX_EVENT_SIZE);
+            message = trimMessage(message, MAX_EVENT_SIZE);
         }
 
-        return inputLogEvent;
+        return InputLogEvent.builder()
+                .timestamp(event.getTimeStamp())
+                .message(message)
+                .build();
     }
 
     // See http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html
@@ -47,19 +49,23 @@ abstract class Worker {
     private static final Charset EVENT_SIZE_CHARSET = Charset.forName("UTF-8");
 
     static final int eventSize(InputLogEvent event) {
-        return event.getMessage().getBytes(EVENT_SIZE_CHARSET).length + EVENT_SIZE_PADDING;
+        return eventSize(event.message());
+    }
+
+    static final int eventSize(String message) {
+        return message.getBytes(EVENT_SIZE_CHARSET).length + EVENT_SIZE_PADDING;
     }
 
     private static final String ELLIPSIS = "...";
 
-    private static final void trimMessage(InputLogEvent event, int eventSize) {
+    private static final String trimMessage(String message, int eventSize) {
         int trimmedMessageSize = eventSize - EVENT_SIZE_PADDING - ELLIPSIS.getBytes(EVENT_SIZE_CHARSET).length;
-        byte[] message = event.getMessage().getBytes(EVENT_SIZE_CHARSET);
+        byte[] messageBytes = message.getBytes(EVENT_SIZE_CHARSET);
 
-        String unsafeTrimmed = new String(message, 0, trimmedMessageSize + 1, EVENT_SIZE_CHARSET);
+        String unsafeTrimmed = new String(messageBytes, 0, trimmedMessageSize + 1, EVENT_SIZE_CHARSET);
         // The last character might be a chopped UTF-8 character
         String trimmed = unsafeTrimmed.substring(0, unsafeTrimmed.length() - 1);
 
-        event.setMessage(trimmed + ELLIPSIS);
+        return trimmed + ELLIPSIS;
     }
 }

--- a/src/test/java/ca/pjer/logback/AsyncWorkerTest.java
+++ b/src/test/java/ca/pjer/logback/AsyncWorkerTest.java
@@ -5,8 +5,8 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.layout.EchoLayout;
-import com.amazonaws.services.logs.model.InputLogEvent;
 import org.junit.Test;
+import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
 
 import java.util.Collection;
 import java.util.UUID;

--- a/src/test/java/ca/pjer/logback/WorkerTest.java
+++ b/src/test/java/ca/pjer/logback/WorkerTest.java
@@ -12,14 +12,13 @@ import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
 
-import com.amazonaws.services.logs.model.InputLogEvent;
-
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.layout.EchoLayout;
+import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
 
 @RunWith(Theories.class)
 public class WorkerTest {
@@ -44,7 +43,7 @@ public class WorkerTest {
     @Theory
     public void eventShouldNotBeTrimmed(@FromDataPoints("UNTRIMMED") String message) {
         InputLogEvent event = worker.asInputLogEvent(asEvent(message));
-        assertFalse(event.getMessage().endsWith("..."));
+        assertFalse(event.message().endsWith("..."));
     }
     
     @DataPoints("TRIMMED")
@@ -58,7 +57,7 @@ public class WorkerTest {
     @Theory
     public void eventShouldBeTrimmed(@FromDataPoints("TRIMMED") String message) {
         InputLogEvent event = worker.asInputLogEvent(asEvent(message));
-        assertTrue(event.getMessage().endsWith("..."));
+        assertTrue(event.message().endsWith("..."));
     }
     
     @DataPoints("TRIMMED_MB")
@@ -70,13 +69,13 @@ public class WorkerTest {
     @Theory
     public void trimmingShouldNotChopMultibyteCharacter(@FromDataPoints("TRIMMED_MB") String message) {
         InputLogEvent event = worker.asInputLogEvent(asEvent(message));
-        assertTrue(event.getMessage().endsWith("ö..."));
+        assertTrue(event.message().endsWith("ö..."));
     }
 
     @Theory
     public void eventShouldNeverExceed262144Bytes(String message) throws UnsupportedEncodingException {
         InputLogEvent event = worker.asInputLogEvent(asEvent(message));
-        int eventSize = event.getMessage().getBytes("UTF-8").length + 26;
+        int eventSize = event.message().getBytes("UTF-8").length + 26;
         assertTrue(eventSize <= 262144);
     }
 


### PR DESCRIPTION
Recently we're migrating to newer Java 16 and the AWS SDK v1 is just not compatible with it. This PR will upgade to use the AWS SDK v2.

As example why v1 is not compatible: when the SDK gets an error response from AWS, the AWS SDK v1 tries to convert the JSON text to a Throwable using Jackson converter. Jackson tries to reflectively set accessibility to `java.lang.Throwable::setCause` but is not allowed on newer Java versions.

It will fail with a stack trace like this:

```
java.lang.reflect.InaccessibleObjectException: Unable to make final void java.lang.Throwable.setCause(java.lang.Throwable) accessible: module java.base does not "opens java.lang" to unnamed module @4c98385c

	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:357)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:199)
	at java.base/java.lang.reflect.Method.setAccessible(Method.java:193)
	at com.fasterxml.jackson.databind.util.ClassUtil.checkAndFixAccess(ClassUtil.java:987)
	at com.fasterxml.jackson.databind.introspect.AnnotatedMember.fixAccess(AnnotatedMember.java:139)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.fixAccess(MethodProperty.java:95)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder._fixAccess(BeanDeserializerBuilder.java:522)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBuilder.build(BeanDeserializerBuilder.java:373)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.buildThrowableDeserializer(BeanDeserializerFactory.java:456)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerFactory.createBeanDeserializer(BeanDeserializerFactory.java:112)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createDeserializer2(DeserializerCache.java:414)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createDeserializer(DeserializerCache.java:349)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCache2(DeserializerCache.java:264)
	at com.fasterxml.jackson.databind.deser.DeserializerCache._createAndCacheValueDeserializer(DeserializerCache.java:244)
	at com.fasterxml.jackson.databind.deser.DeserializerCache.findValueDeserializer(DeserializerCache.java:142)
	at com.fasterxml.jackson.databind.DeserializationContext.findRootValueDeserializer(DeserializationContext.java:591)
	at com.fasterxml.jackson.databind.ObjectMapper._findRootDeserializer(ObjectMapper.java:4733)
	at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:4569)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2798)
	at com.fasterxml.jackson.databind.ObjectMapper.treeToValue(ObjectMapper.java:3261)
	at com.amazonaws.transform.JsonErrorUnmarshaller.unmarshall(JsonErrorUnmarshaller.java:52)
```

Upgrading to latest Jackson does not prevent this error, and although there are some tweaking options possible for the Jackson ObjectMapper to prevent it from setting accessibility, it would require modifying the AWS SDK v1 which does not seem eager to accept patches.

One alternative is to upgrade the AWS SDK to v2, as presented here in this PR.