### PR TITLE
Add support for S3 bucket upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Thank you for your help:
             <version>1.7.21</version>
         </dependency>
         <dependency>
-            <groupId>ca.pjer</groupId>
+            <groupId>io.github.dnovitski</groupId>
             <artifactId>logback-awslogs-appender</artifactId>
             <version>1.7.0</version>
         </dependency>

--- a/README.md
+++ b/README.md
@@ -2,13 +2,18 @@
 
 # Logback AWSLogs appender
 
-An [Amazon Web Services](https://aws.amazon.com) [CloudWatch Logs](http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/Welcome.html) [appender](http://logback.qos.ch/manual/appenders.html) for [Logback](http://logback.qos.ch/).
+An [appender](http://logback.qos.ch/manual/appenders.html) for [Logback](http://logback.qos.ch/) to ship logs to [Amazon Web Services](https://aws.amazon.com).
+
+Supports shipping to:
+* [CloudWatch Logs](http://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/Welcome.html)
+* [S3 buckets](https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html)
 
 Thank you for your help:
 - [ivanfmartinez](https://github.com/ivanfmartinez)
 - [jochenschneider](https://github.com/jochenschneider)
 - [malkusch](https://github.com/malkusch)
 - [robertoestivill](https://github.com/robertoestivill)
+- [dnovitski](https://github.com/dnovitski)
 
 ## Quick start
 
@@ -25,7 +30,7 @@ Thank you for your help:
         <dependency>
             <groupId>ca.pjer</groupId>
             <artifactId>logback-awslogs-appender</artifactId>
-            <version>1.4.0</version>
+            <version>1.7.0</version>
         </dependency>
     </dependencies>
 </project>
@@ -88,7 +93,7 @@ logger.info("HelloWorld");
 
 ## More configurations
 
-It may be worth quoting this from _AWS_, beacause this is why we need to have unique `logStreamName`:
+It may be worth quoting this from _AWS_, because this is why we need to have unique `logStreamName`:
 
 > When you have two processes attempting to perform the PutLogEvents API call to the same log stream, there is a chance that one will pass and one will fail because of the sequence token provided for that same log stream. Because of the sequencing of these events maintained in the log stream, you cannot have concurrently running processes pushing to the same log-stream.
 
@@ -124,6 +129,12 @@ A real life `logback.xml` would probably look like this (when all options are sp
         <!-- Log Stream Name UUID Prefix -->
         <logStreamUuidPrefix>mystream/</logStreamUuidPrefix>
 
+        <!-- Or alternatively, Log Stream Name via pattern generated upon application startup -->
+        <!-- Supported tokens are:
+          %{uuid} - Random generated UUID
+          %{datetime} - Current date in yyyymmddhhmmss format -->
+        <logStreamNamePattern>mystream/%{uuid}</logStreamNamePattern>
+ 
         <!-- Hardcoded AWS region -->
         <!-- So even when running inside an AWS instance in us-west-1, logs will go to us-west-2 -->
         <logRegion>us-west-2</logRegion>
@@ -149,6 +160,27 @@ A real life `logback.xml` would probably look like this (when all options are sp
         <!-- Use custom credential instead of DefaultCredentialsProvider -->
         <accessKeyId>YOUR_ACCESS_KEY_ID</accessKeyId>
         <secretAccessKey>YOUR_SECRET_ACCESS_KEY</secretAccessKey>
+        
+        <!-- Alternatively, to upload logs to S3 buckets, configure a bucket name and bucket path -->
+        <bucketName>mybucket</bucketName>
+        <!-- Supported tokens are:
+            %{log_group} - The log group specified above
+            %{log_stream} - The log stream specified above
+            %{date} - Current date in yyyy-mm-dd format
+            %{uuid} - Random generated UUID, unique for each call
+            %{millis} - Current system timestamp in millis
+            %{nanos} - Current system timestamp in nanos
+            %{counter} - Atomic counter incremented each call
+            
+            Log files uploaded to S3 will be JSON files using "Records" JSON array format supported by Filebeat. 
+        -->
+        <bucketPath>logs/log_group=%{log_group}/date=%{date}/log_stream=%{log_stream}/%{counter}.log</bucketPath>
+      
+        <!-- Use 's3' to upload to S3 buckets, otherwise 'cloudwatch' is the default -->
+        <logOutputType>s3</logOutputType>
+
+        <!-- Use 'json' to specify logs are in json format, 'text' for plaintext, and nothing to autodetect when needed (default) --> 
+        <logFormatType>text</logFormatType>
     </appender>
 
     <!-- A console output -->

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Thank you for your help:
             <version>1.7.21</version>
         </dependency>
         <dependency>
-            <groupId>io.github.dnovitski</groupId>
+            <groupId>ca.pjer</groupId>
             <artifactId>logback-awslogs-appender</artifactId>
-            <version>1.7.0</version>
+            <version>1.7.2</version>
         </dependency>
     </dependencies>
 </project>
@@ -174,13 +174,20 @@ A real life `logback.xml` would probably look like this (when all options are sp
             
             Log files uploaded to S3 will be JSON files using "Records" JSON array format supported by Filebeat. 
         -->
-        <bucketPath>logs/log_group=%{log_group}/date=%{date}/log_stream=%{log_stream}/%{counter}.log</bucketPath>
+        <bucketPath>logs/log_group=%{log_group}/date=%{date}/log_stream=%{log_stream}/%{counter}.json.gz</bucketPath>
       
         <!-- Use 's3' to upload to S3 buckets, otherwise 'cloudwatch' is the default -->
         <logOutputType>s3</logOutputType>
 
-        <!-- Use 'json' to specify logs are in json format, 'text' for plaintext, and nothing to autodetect when needed (default) --> 
-        <logFormatType>text</logFormatType>
+        <!-- Use 'json' to specify input logs are in json format, 'text' for plaintext, and nothing to autodetect when needed (default) --> 
+        <logFormatType>json</logFormatType>
+
+        <!-- Use 'json_hive' to concatenate each log event as a single line json object, 'json_array' for [ {...} , ... ]', or json_records_array' for { "Records" : [ {...}, ... ] }  -->
+        <s3FileFormat>json_hive</s3FileFormat>
+
+        <!-- Specify GZIP compression level, default 1. Only used if the bucketPath ends with .gz -->
+        <s3FileCompressionLevel>1</s3FileCompressionLevel>
+
     </appender>
 
     <!-- A console output -->

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>ca.pjer</groupId>
     <artifactId>logback-awslogs-appender</artifactId>
-    <version>1.6.0</version>
+    <version>1.7.0</version>
 
     <name>Logback AWSLogs appender</name>
     <description>An Amazon Web Services (AWS) Logs (CloudWatch) appender for Logback</description>
@@ -60,6 +60,11 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>cloudwatchlogs</artifactId>
+            <version>2.16.65</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
             <version>2.16.65</version>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>ca.pjer</groupId>
     <artifactId>logback-awslogs-appender</artifactId>
-    <version>1.7.1</version>
+    <version>1.7.2</version>
 
     <name>Logback AWSLogs appender</name>
     <description>An Amazon Web Services (AWS) Logs (CloudWatch) appender for Logback</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>ca.pjer</groupId>
     <artifactId>logback-awslogs-appender</artifactId>
-    <version>1.7.0</version>
+    <version>1.7.1</version>
 
     <name>Logback AWSLogs appender</name>
     <description>An Amazon Web Services (AWS) Logs (CloudWatch) appender for Logback</description>

--- a/src/main/java/ca/pjer/logback/AWSLogsStub.java
+++ b/src/main/java/ca/pjer/logback/AWSLogsStub.java
@@ -45,7 +45,13 @@ class AWSLogsStub {
 
     synchronized void stop() {
         try {
-            awsLogs().close();
+            AwsLogsClient awsLogsClient = lazyAwsLogsClient.get();
+            if (awsLogsClient != null) {
+                if (properties.isVerbose()) {
+                    System.out.println("Closing AWSLogs Client");
+                }
+                awsLogsClient.close();
+            }
         } catch (Exception e) {
             // ignore
         }

--- a/src/main/java/ca/pjer/logback/AWSLogsStub.java
+++ b/src/main/java/ca/pjer/logback/AWSLogsStub.java
@@ -1,110 +1,44 @@
 package ca.pjer.logback;
 
+import ca.pjer.logback.client.AwsLogsClient;
+import ca.pjer.logback.client.AwsLogsClientProperties;
+import ca.pjer.logback.client.AwsLogsCloudWatchClient;
+import ca.pjer.logback.client.AwsLogsS3Client;
 import ca.pjer.logback.metrics.AwsLogsMetricsHolder;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
-import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClientBuilder;
-import software.amazon.awssdk.services.cloudwatchlogs.model.*;
+import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.*;
 
 class AWSLogsStub {
+    private static final String LOG_OUTPUT_TYPE_S3 = "s3";
+    private static final String LOG_OUTPUT_TYPE_CLOUDWATCH = "cloudwatch";
+
     private final Comparator<InputLogEvent> inputLogEventByTimestampComparator = Comparator.comparing(InputLogEvent::timestamp);
-    private final String logGroupName;
-    private final String logStreamName;
-    private final String logRegion;
-    private final String cloudWatchEndpoint;
-    private final boolean verbose;
-    private final String accessKeyId;
-    private final String secretAccessKey;
-    private String sequenceToken;
     private Long lastTimestamp;
-    private int retentionTimeInDays;
 
-    private final Lazy<CloudWatchLogsClient> lazyAwsLogs = new Lazy<>();
+    private final Lazy<AwsLogsClient> lazyAwsLogsClient = new Lazy<>();
+    private final AwsLogsClientProperties properties;
 
-    AWSLogsStub(String logGroupName, String logStreamName, String logRegion, int retentionTimeInDays
-            , String cloudWatchEndpoint, boolean verbose, String accessKeyId, String secretAccessKey) {
-        this.logGroupName = logGroupName;
-        this.logStreamName = logStreamName;
-        this.logRegion = logRegion;
-        this.retentionTimeInDays = retentionTimeInDays;
-        this.cloudWatchEndpoint = cloudWatchEndpoint;
-        this.verbose = verbose;
-        this.accessKeyId = accessKeyId;
-        this.secretAccessKey = secretAccessKey;
+    AWSLogsStub(AwsLogsClientProperties properties) {
+        this.properties = properties;
     }
 
-    private CloudWatchLogsClient awsLogs() {
-        return lazyAwsLogs.getOrCompute(() -> {
-            if (verbose) {
+    private AwsLogsClient awsLogs() {
+        return lazyAwsLogsClient.getOrCompute(() -> {
+            if (properties.isVerbose()) {
                 System.out.println("Creating AWSLogs Client");
             }
 
-            CloudWatchLogsClientBuilder builder = CloudWatchLogsClient.builder();
-
-            if (Objects.nonNull(cloudWatchEndpoint)) {
-                try {
-                    builder = builder.endpointOverride(new URI(cloudWatchEndpoint));
-                } catch (URISyntaxException e) {
-                    if (verbose) {
-                        System.out.println("Invalid endpoint endpoint URL: " + cloudWatchEndpoint);
-                    }
-                }
+            if (LOG_OUTPUT_TYPE_S3.equals(properties.getLogOutputType())) {
+                return new AwsLogsS3Client(properties);
+            } else if (LOG_OUTPUT_TYPE_CLOUDWATCH.equals(properties.getLogOutputType()) || Objects.isNull(properties.getLogOutputType())) {
+                return new AwsLogsCloudWatchClient(properties);
+            } else {
+                throw new RuntimeException("Unknown log output type: " + properties.getLogOutputType());
             }
-
-            if (Objects.nonNull(logRegion)) {
-                builder = builder.region(Region.of(logRegion));
-            }
-
-            if (Objects.nonNull(this.accessKeyId) && Objects.nonNull(this.secretAccessKey)) {
-                AwsCredentialsProvider credentialProvider = StaticCredentialsProvider.create(
-                        AwsBasicCredentials.create(this.accessKeyId, this.secretAccessKey));
-                builder.credentialsProvider(credentialProvider);
-            }
-
-            CloudWatchLogsClient awsLogs = builder.build();
-            initLogGroup(awsLogs);
-            return awsLogs;
         });
     }
 
-    private void initLogGroup(CloudWatchLogsClient awsLogs) {
-        try {
-            awsLogs.createLogGroup(CreateLogGroupRequest.builder()
-                    .logGroupName(logGroupName)
-                    .build());
-            if (retentionTimeInDays > 0) {
-                awsLogs.putRetentionPolicy(PutRetentionPolicyRequest.builder()
-                        .logGroupName(logGroupName)
-                        .retentionInDays(retentionTimeInDays)
-                        .build());
-            }
-        } catch (ResourceAlreadyExistsException e) {
-            // ignore
-        } catch (Throwable t) {
-            if (verbose) {
-                t.printStackTrace();
-            }
-        }
-        try {
-            awsLogs.createLogStream(CreateLogStreamRequest.builder()
-                    .logGroupName(logGroupName)
-                    .logStreamName(logStreamName)
-                    .build());
-        } catch (ResourceAlreadyExistsException e) {
-            // ignore
-        } catch (Throwable t) {
-            if (verbose) {
-                t.printStackTrace();
-            }
-        }
-    }
 
     synchronized void start() {
     }
@@ -137,30 +71,10 @@ class AWSLogsStub {
         }
         AwsLogsMetricsHolder.get().incrementLogEvents(correctedEvents.size());
         AwsLogsMetricsHolder.get().incrementPutLog();
-        logPreparedEvents(correctedEvents);
+        sendLogEvents(correctedEvents);
     }
 
-    private void logPreparedEvents(Collection<InputLogEvent> events) {
-        try {
-            PutLogEventsRequest request = PutLogEventsRequest.builder()
-                    .logGroupName(logGroupName)
-                    .logStreamName(logStreamName)
-                    .sequenceToken(sequenceToken)
-                    .logEvents(events)
-                    .build();
-            PutLogEventsResponse result = awsLogs().putLogEvents(request);
-            sequenceToken = result.nextSequenceToken();
-        } catch (DataAlreadyAcceptedException e) {
-            sequenceToken = e.expectedSequenceToken();
-        } catch (InvalidSequenceTokenException e) {
-            sequenceToken = e.expectedSequenceToken();
-            logPreparedEvents(events);
-        } catch (Throwable t) {
-            if (verbose) {
-                t.printStackTrace();
-            }
-            AwsLogsMetricsHolder.get().incrementPutLogFailed(t);
-            throw t;
-        }
+    private void sendLogEvents(Collection<InputLogEvent> events) {
+        awsLogs().sendLogs(events);
     }
 }

--- a/src/main/java/ca/pjer/logback/AwsLogsAppender.java
+++ b/src/main/java/ca/pjer/logback/AwsLogsAppender.java
@@ -37,6 +37,8 @@ public class AwsLogsAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     private String bucketPath;
     private String logFormatType;
     private String logOutputType;
+    private String s3FileFormat;
+    private Integer s3FileCompressionLevel;
     private String timezone;
 
     private AWSLogsStub awsLogsStub;
@@ -267,6 +269,26 @@ public class AwsLogsAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
     }
 
     @SuppressWarnings({"unused", "WeakerAccess"})
+    public String getS3FileFormat() {
+        return s3FileFormat;
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public void setS3FileFormat(String s3FileFormat) {
+        this.s3FileFormat = s3FileFormat;
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public Integer getS3FileCompressionLevel() {
+        return s3FileCompressionLevel;
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
+    public void setS3FileCompressionLevel(Integer s3FileCompressionLevel) {
+        this.s3FileCompressionLevel = s3FileCompressionLevel;
+    }
+
+    @SuppressWarnings({"unused", "WeakerAccess"})
     public String getTimezone() {
         return timezone;
     }
@@ -301,7 +323,7 @@ public class AwsLogsAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
             ZoneId zoneId = (timezone == null) ? ZoneId.systemDefault() : ZoneId.of(timezone);
 
             if (this.awsLogsStub == null) {
-                this.awsLogsStub = new AWSLogsStub(new AwsLogsClientProperties(logGroupName, logStreamName, logRegion, retentionTimeDays, endpoint, verbose, accessKeyId, secretAccessKey, bucketName, bucketPath, logFormatType, logOutputType, zoneId));
+                this.awsLogsStub = new AWSLogsStub(new AwsLogsClientProperties(logGroupName, logStreamName, logRegion, retentionTimeDays, endpoint, verbose, accessKeyId, secretAccessKey, bucketName, bucketPath, logFormatType, logOutputType, zoneId, s3FileFormat, s3FileCompressionLevel));
                 this.awsLogsStub.start();
             }
             if (this.worker == null) {

--- a/src/main/java/ca/pjer/logback/Lazy.java
+++ b/src/main/java/ca/pjer/logback/Lazy.java
@@ -7,9 +7,13 @@ import static java.util.Objects.requireNonNull;
 class Lazy<T> {
     private volatile T value;
 
-    T getOrCompute(Supplier<T> supplier) {
+    public T getOrCompute(Supplier<T> supplier) {
         final T result = value;  // Read volatile just once...
         return result == null ? maybeCompute(supplier) : result;
+    }
+
+    public T get() {
+        return value;
     }
 
     private synchronized T maybeCompute(Supplier<T> supplier) {

--- a/src/main/java/ca/pjer/logback/client/AwsLogsClient.java
+++ b/src/main/java/ca/pjer/logback/client/AwsLogsClient.java
@@ -1,0 +1,11 @@
+package ca.pjer.logback.client;
+
+import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
+
+import java.util.Collection;
+
+public interface AwsLogsClient {
+    void close();
+
+    void sendLogs(Collection<InputLogEvent> events);
+}

--- a/src/main/java/ca/pjer/logback/client/AwsLogsClientProperties.java
+++ b/src/main/java/ca/pjer/logback/client/AwsLogsClientProperties.java
@@ -1,0 +1,87 @@
+package ca.pjer.logback.client;
+
+import java.time.ZoneId;
+
+public class AwsLogsClientProperties {
+    private final String logGroupName;
+    private final String logStreamName;
+    private final String logRegion;
+    private final String logFormatType;
+    private final String logOutputType;
+    private final String endpoint;
+    private final boolean verbose;
+    private final String accessKeyId;
+    private final String secretAccessKey;
+    private final int retentionTimeInDays;
+    private final String bucketName;
+    private final String bucketPath;
+    private final ZoneId zoneId;
+
+    public AwsLogsClientProperties(String logGroupName, String logStreamName, String logRegion, int retentionTimeInDays, String cloudWatchEndpoint, boolean verbose, String accessKeyId, String secretAccessKey, String bucketName, String bucketPath, String logFormatType, String logOutputType, ZoneId zoneId) {
+        this.logGroupName = logGroupName;
+        this.logStreamName = logStreamName;
+        this.logRegion = logRegion;
+        this.retentionTimeInDays = retentionTimeInDays;
+        this.endpoint = cloudWatchEndpoint;
+        this.verbose = verbose;
+        this.accessKeyId = accessKeyId;
+        this.secretAccessKey = secretAccessKey;
+        this.bucketName = bucketName;
+        this.bucketPath = bucketPath;
+        this.logFormatType = logFormatType;
+        this.logOutputType = logOutputType;
+        this.zoneId = zoneId;
+    }
+
+    public String getLogGroupName() {
+        return logGroupName;
+    }
+
+    public String getLogStreamName() {
+        return logStreamName;
+    }
+
+    public String getLogRegion() {
+        return logRegion;
+    }
+
+    public String getLogFormatType() {
+        return logFormatType;
+    }
+
+    public String getLogOutputType() {
+        return logOutputType;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public boolean isVerbose() {
+        return verbose;
+    }
+
+    public String getAccessKeyId() {
+        return accessKeyId;
+    }
+
+    public String getSecretAccessKey() {
+        return secretAccessKey;
+    }
+
+    public int getRetentionTimeInDays() {
+        return retentionTimeInDays;
+    }
+
+    public String getBucketName() {
+        return bucketName;
+    }
+
+    public String getBucketPath() {
+        return bucketPath;
+    }
+
+    public ZoneId getZoneId() {
+        return zoneId;
+    }
+}

--- a/src/main/java/ca/pjer/logback/client/AwsLogsClientProperties.java
+++ b/src/main/java/ca/pjer/logback/client/AwsLogsClientProperties.java
@@ -16,8 +16,10 @@ public class AwsLogsClientProperties {
     private final String bucketName;
     private final String bucketPath;
     private final ZoneId zoneId;
+    private final String s3FileFormat;
+    private final Integer s3FileCompressionLevel;
 
-    public AwsLogsClientProperties(String logGroupName, String logStreamName, String logRegion, int retentionTimeInDays, String cloudWatchEndpoint, boolean verbose, String accessKeyId, String secretAccessKey, String bucketName, String bucketPath, String logFormatType, String logOutputType, ZoneId zoneId) {
+    public AwsLogsClientProperties(String logGroupName, String logStreamName, String logRegion, int retentionTimeInDays, String cloudWatchEndpoint, boolean verbose, String accessKeyId, String secretAccessKey, String bucketName, String bucketPath, String logFormatType, String logOutputType, ZoneId zoneId, String s3FileFormat, Integer s3FileCompressionLevel) {
         this.logGroupName = logGroupName;
         this.logStreamName = logStreamName;
         this.logRegion = logRegion;
@@ -31,6 +33,8 @@ public class AwsLogsClientProperties {
         this.logFormatType = logFormatType;
         this.logOutputType = logOutputType;
         this.zoneId = zoneId;
+        this.s3FileFormat = s3FileFormat;
+        this.s3FileCompressionLevel = s3FileCompressionLevel;
     }
 
     public String getLogGroupName() {
@@ -45,10 +49,12 @@ public class AwsLogsClientProperties {
         return logRegion;
     }
 
+    // Specifies the input log event format, eg text, json, or autodetect (null)
     public String getLogFormatType() {
         return logFormatType;
     }
 
+    // Specifies the output type: where to ship logs to, eg s3 or cloudwatch
     public String getLogOutputType() {
         return logOutputType;
     }
@@ -83,5 +89,14 @@ public class AwsLogsClientProperties {
 
     public ZoneId getZoneId() {
         return zoneId;
+    }
+
+    // Specifies the s3 file format, eg json records array, json hive
+    public String getS3FileFormat() {
+        return s3FileFormat;
+    }
+
+    public Integer getS3FileCompressionLevel() {
+        return s3FileCompressionLevel == null ? 1 : s3FileCompressionLevel;
     }
 }

--- a/src/main/java/ca/pjer/logback/client/AwsLogsCloudWatchClient.java
+++ b/src/main/java/ca/pjer/logback/client/AwsLogsCloudWatchClient.java
@@ -28,7 +28,7 @@ public class AwsLogsCloudWatchClient implements AwsLogsClient {
                 builder = builder.endpointOverride(new URI(properties.getEndpoint()));
             } catch (URISyntaxException e) {
                 if (properties.isVerbose()) {
-                    System.out.println("Invalid endpoint endpoint URL: " + properties.getEndpoint());
+                    System.out.println("Invalid endpoint URL: " + properties.getEndpoint());
                 }
             }
         }

--- a/src/main/java/ca/pjer/logback/client/AwsLogsCloudWatchClient.java
+++ b/src/main/java/ca/pjer/logback/client/AwsLogsCloudWatchClient.java
@@ -1,0 +1,111 @@
+package ca.pjer.logback.client;
+
+import ca.pjer.logback.metrics.AwsLogsMetricsHolder;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClient;
+import software.amazon.awssdk.services.cloudwatchlogs.CloudWatchLogsClientBuilder;
+import software.amazon.awssdk.services.cloudwatchlogs.model.*;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.Objects;
+
+public class AwsLogsCloudWatchClient implements AwsLogsClient {
+    private final AwsLogsClientProperties properties;
+    private final CloudWatchLogsClient client;
+    private String sequenceToken;
+
+    public AwsLogsCloudWatchClient(AwsLogsClientProperties properties) {
+        this.properties = properties;
+        CloudWatchLogsClientBuilder builder = CloudWatchLogsClient.builder();
+
+        if (Objects.nonNull(properties.getEndpoint())) {
+            try {
+                builder = builder.endpointOverride(new URI(properties.getEndpoint()));
+            } catch (URISyntaxException e) {
+                if (properties.isVerbose()) {
+                    System.out.println("Invalid endpoint endpoint URL: " + properties.getEndpoint());
+                }
+            }
+        }
+
+        if (Objects.nonNull(properties.getLogRegion())) {
+            builder = builder.region(Region.of(properties.getLogRegion()));
+        }
+
+        if (Objects.nonNull(properties.getAccessKeyId()) && Objects.nonNull(properties.getSecretAccessKey())) {
+            AwsCredentialsProvider credentialProvider = StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(properties.getAccessKeyId(), properties.getSecretAccessKey()));
+            builder.credentialsProvider(credentialProvider);
+        }
+
+        client = builder.build();
+        initLogGroup(client);
+    }
+
+    private void initLogGroup(CloudWatchLogsClient awsLogs) {
+        try {
+            awsLogs.createLogGroup(CreateLogGroupRequest.builder()
+                    .logGroupName(properties.getLogGroupName())
+                    .build());
+            if (properties.getRetentionTimeInDays() > 0) {
+                awsLogs.putRetentionPolicy(PutRetentionPolicyRequest.builder()
+                        .logGroupName(properties.getLogGroupName())
+                        .retentionInDays(properties.getRetentionTimeInDays())
+                        .build());
+            }
+        } catch (ResourceAlreadyExistsException e) {
+            // ignore
+        } catch (Throwable t) {
+            if (properties.isVerbose()) {
+                t.printStackTrace();
+            }
+        }
+        try {
+            awsLogs.createLogStream(CreateLogStreamRequest.builder()
+                    .logGroupName(properties.getLogGroupName())
+                    .logStreamName(properties.getLogStreamName())
+                    .build());
+        } catch (ResourceAlreadyExistsException e) {
+            // ignore
+        } catch (Throwable t) {
+            if (properties.isVerbose()) {
+                t.printStackTrace();
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public void sendLogs(Collection<InputLogEvent> events) {
+        try {
+            PutLogEventsRequest request = PutLogEventsRequest.builder()
+                    .logGroupName(properties.getLogGroupName())
+                    .logStreamName(properties.getLogStreamName())
+                    .sequenceToken(sequenceToken)
+                    .logEvents(events)
+                    .build();
+            PutLogEventsResponse result = client.putLogEvents(request);
+            sequenceToken = result.nextSequenceToken();
+        } catch (DataAlreadyAcceptedException e) {
+            sequenceToken = e.expectedSequenceToken();
+        } catch (InvalidSequenceTokenException e) {
+            sequenceToken = e.expectedSequenceToken();
+            sendLogs(events);
+        } catch (Throwable t) {
+            if (properties.isVerbose()) {
+                t.printStackTrace();
+            }
+            AwsLogsMetricsHolder.get().incrementPutLogFailed(t);
+            throw t;
+        }
+    }
+}

--- a/src/main/java/ca/pjer/logback/client/AwsLogsS3Client.java
+++ b/src/main/java/ca/pjer/logback/client/AwsLogsS3Client.java
@@ -1,0 +1,144 @@
+package ca.pjer.logback.client;
+
+import ca.pjer.logback.metrics.AwsLogsMetricsHolder;
+import ca.pjer.logback.tokenisation.TokenUtility;
+import com.fasterxml.jackson.core.JsonEncoding;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatchlogs.model.InputLogEvent;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+public class AwsLogsS3Client implements AwsLogsClient {
+    private static final String RECORDS = "Records";
+    private static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";
+    private static final String DEFAULT_BUCKET_PATH = "logs/log_group=%{log_group}/date=%{date}/log_stream=%{log_stream}/%{uuid}.log";
+    private static final String LOG_FORMAT_TYPE_JSON = "json";
+    private final AwsLogsClientProperties properties;
+    private final S3Client client;
+    private final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private final JsonFactory jsonFactory = new JsonFactory();
+    private final AtomicLong counter = new AtomicLong(0);
+    private final Map<String, Supplier<String>> bucketPathTokenSuppliers = new HashMap<>();
+
+    public AwsLogsS3Client(AwsLogsClientProperties properties) {
+        this.properties = properties;
+        S3ClientBuilder builder = S3Client.builder();
+
+        if (Objects.nonNull(properties.getEndpoint())) {
+            try {
+                builder = builder.endpointOverride(new URI(properties.getEndpoint()));
+            } catch (URISyntaxException e) {
+                if (properties.isVerbose()) {
+                    System.out.println("Invalid endpoint endpoint URL: " + properties.getEndpoint());
+                }
+            }
+        }
+
+        if (Objects.nonNull(properties.getLogRegion())) {
+            builder = builder.region(Region.of(properties.getLogRegion()));
+        }
+
+        if (Objects.nonNull(properties.getAccessKeyId()) && Objects.nonNull(properties.getSecretAccessKey())) {
+            AwsCredentialsProvider credentialProvider = StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(properties.getAccessKeyId(), properties.getSecretAccessKey()));
+            builder.credentialsProvider(credentialProvider);
+        }
+
+        client = builder.build();
+        bucketPathTokenSuppliers.put("log_group", () -> properties.getLogGroupName());
+        bucketPathTokenSuppliers.put("log_stream", () -> properties.getLogStreamName());
+        bucketPathTokenSuppliers.put("date", () -> dateFormatter.format(Instant.now().atZone(properties.getZoneId())));
+        bucketPathTokenSuppliers.put("uuid", () -> UUID.randomUUID().toString());
+        bucketPathTokenSuppliers.put("millis", () -> String.format("%020d", System.currentTimeMillis()));
+        bucketPathTokenSuppliers.put("nanos", () -> String.format("%020d", System.nanoTime()));
+        bucketPathTokenSuppliers.put("counter", () -> String.format("%020d", counter.getAndIncrement()));
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+
+    @Override
+    public void sendLogs(Collection<InputLogEvent> events) {
+        try {
+            String objectKey = buildLogFilename();
+            PutObjectRequest putOb = PutObjectRequest.builder()
+                    .bucket(properties.getBucketName())
+                    .key(objectKey)
+                    .build();
+
+            byte[] bytes = buildLogBytes(events);
+            client.putObject(putOb, RequestBody.fromContentProvider(() -> new ByteArrayInputStream(bytes), bytes.length, CONTENT_TYPE_APPLICATION_JSON));
+        } catch (Throwable t) {
+            if (properties.isVerbose()) {
+                t.printStackTrace();
+            }
+            AwsLogsMetricsHolder.get().incrementPutLogFailed(t);
+            throw t;
+        }
+    }
+
+    private byte[] buildLogBytes(Collection<InputLogEvent> events) {
+        try {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            JsonGenerator jsonGenerator = jsonFactory.createGenerator(outputStream, JsonEncoding.UTF8);
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeFieldName(RECORDS);
+            jsonGenerator.writeStartArray();
+
+            for (InputLogEvent event : events) {
+                String message = event.message();
+                if (isJsonFormat(message)) {
+                    jsonGenerator.writeRawValue(message);
+                } else { // Plain text lines probably
+                    jsonGenerator.writeStartObject();
+                    jsonGenerator.writeStringField("@timestamp", DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(Instant.ofEpochMilli(event.timestamp()).atZone(properties.getZoneId())));
+                    jsonGenerator.writeStringField("message", event.message());
+                    jsonGenerator.writeEndObject();
+                }
+            }
+            jsonGenerator.writeEndArray();
+            jsonGenerator.writeEndObject();
+            jsonGenerator.close();
+
+            return outputStream.toByteArray();
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
+    }
+
+    private boolean isJsonFormat(String message) {
+        if (Objects.nonNull(properties.getLogFormatType())) {
+            return LOG_FORMAT_TYPE_JSON.equals(properties.getLogOutputType());
+        }
+
+        if (!message.startsWith("{")) {
+            return false;
+        }
+
+        return message.endsWith("}\n") || message.endsWith("}");
+    }
+
+    private String buildLogFilename() {
+        String path = Objects.nonNull(properties.getBucketPath()) ? properties.getBucketPath() : DEFAULT_BUCKET_PATH;
+        return TokenUtility.replaceTokens(path, bucketPathTokenSuppliers);
+    }
+}

--- a/src/main/java/ca/pjer/logback/client/AwsLogsS3Client.java
+++ b/src/main/java/ca/pjer/logback/client/AwsLogsS3Client.java
@@ -1,10 +1,12 @@
 package ca.pjer.logback.client;
 
+import ca.pjer.logback.compression.CompressionUtilility;
 import ca.pjer.logback.metrics.AwsLogsMetricsHolder;
 import ca.pjer.logback.tokenisation.TokenUtility;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.util.MinimalPrettyPrinter;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -17,8 +19,10 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -30,6 +34,9 @@ public class AwsLogsS3Client implements AwsLogsClient {
     private static final String CONTENT_TYPE_APPLICATION_JSON = "application/json";
     private static final String DEFAULT_BUCKET_PATH = "logs/log_group=%{log_group}/date=%{date}/log_stream=%{log_stream}/%{uuid}.log";
     private static final String LOG_FORMAT_TYPE_JSON = "json";
+    private static final String FILE_FORMAT_JSON_HIVE = "json_hive";
+    private static final String FILE_FORMAT_JSON_ARRAY = "json_array";
+    private static final String FILE_FORMAT_JSON_RECORDS_ARRAY = "json_records_array";
     private final AwsLogsClientProperties properties;
     private final S3Client client;
     private final DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
@@ -85,7 +92,7 @@ public class AwsLogsS3Client implements AwsLogsClient {
                     .key(objectKey)
                     .build();
 
-            byte[] bytes = buildLogBytes(events);
+            byte[] bytes = compressGzip(buildLogBytes(events), objectKey.endsWith(".gz"));
             client.putObject(putOb, RequestBody.fromContentProvider(() -> new ByteArrayInputStream(bytes), bytes.length, CONTENT_TYPE_APPLICATION_JSON));
         } catch (Throwable t) {
             if (properties.isVerbose()) {
@@ -100,28 +107,50 @@ public class AwsLogsS3Client implements AwsLogsClient {
         try {
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             JsonGenerator jsonGenerator = jsonFactory.createGenerator(outputStream, JsonEncoding.UTF8);
-            jsonGenerator.writeStartObject();
-            jsonGenerator.writeFieldName(RECORDS);
-            jsonGenerator.writeStartArray();
+            jsonGenerator.setPrettyPrinter(new MinimalPrettyPrinter(""));
 
-            for (InputLogEvent event : events) {
-                String message = event.message();
-                if (isJsonFormat(message)) {
-                    jsonGenerator.writeRawValue(message);
-                } else { // Plain text lines probably
-                    jsonGenerator.writeStartObject();
-                    jsonGenerator.writeStringField("@timestamp", DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(Instant.ofEpochMilli(event.timestamp()).atZone(properties.getZoneId())));
-                    jsonGenerator.writeStringField("message", event.message());
-                    jsonGenerator.writeEndObject();
+            if (FILE_FORMAT_JSON_HIVE.equals(properties.getS3FileFormat()) || properties.getS3FileFormat() == null) {
+                // JSON Hive format places each event record as a single line with the JSON object, terminated with a new line
+                for (InputLogEvent event : events) {
+                    appendLogJsonLogEvent(jsonGenerator, event);
                 }
+            } else if (FILE_FORMAT_JSON_ARRAY.equals(properties.getS3FileFormat())) {
+                // Use the following JSON format: [ ... ]
+                jsonGenerator.writeStartArray();
+
+                for (InputLogEvent event : events) {
+                    appendLogJsonLogEvent(jsonGenerator, event);
+                }
+                jsonGenerator.writeEndArray();
+            } else if (FILE_FORMAT_JSON_RECORDS_ARRAY.equals(properties.getS3FileFormat())){
+                // Use the following JSON format: { "Records" : [ ... ] }
+                jsonGenerator.writeStartObject();
+                jsonGenerator.writeFieldName(RECORDS);
+                jsonGenerator.writeStartArray();
+
+                for (InputLogEvent event : events) {
+                    appendLogJsonLogEvent(jsonGenerator, event);
+                }
+                jsonGenerator.writeEndArray();
+                jsonGenerator.writeEndObject();
             }
-            jsonGenerator.writeEndArray();
-            jsonGenerator.writeEndObject();
             jsonGenerator.close();
 
             return outputStream.toByteArray();
         } catch (Throwable t) {
             throw new RuntimeException(t);
+        }
+    }
+
+    private void appendLogJsonLogEvent(JsonGenerator jsonGenerator, InputLogEvent event) throws IOException {
+        String message = event.message();
+        if (isJsonFormat(message)) {
+            jsonGenerator.writeRawValue(message);
+        } else { // Plain text lines probably
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeStringField("@timestamp", DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(Instant.ofEpochMilli(event.timestamp()).atZone(properties.getZoneId())));
+            jsonGenerator.writeStringField("message", event.message());
+            jsonGenerator.writeEndObject();
         }
     }
 
@@ -140,5 +169,13 @@ public class AwsLogsS3Client implements AwsLogsClient {
     private String buildLogFilename() {
         String path = Objects.nonNull(properties.getBucketPath()) ? properties.getBucketPath() : DEFAULT_BUCKET_PATH;
         return TokenUtility.replaceTokens(path, bucketPathTokenSuppliers);
+    }
+
+    private byte[] compressGzip(byte[] bytes, boolean enable) {
+        if (enable) {
+            return CompressionUtilility.compressGzip(bytes, properties.getS3FileCompressionLevel());
+        }
+
+        return bytes;
     }
 }

--- a/src/main/java/ca/pjer/logback/client/AwsLogsS3Client.java
+++ b/src/main/java/ca/pjer/logback/client/AwsLogsS3Client.java
@@ -46,7 +46,7 @@ public class AwsLogsS3Client implements AwsLogsClient {
                 builder = builder.endpointOverride(new URI(properties.getEndpoint()));
             } catch (URISyntaxException e) {
                 if (properties.isVerbose()) {
-                    System.out.println("Invalid endpoint endpoint URL: " + properties.getEndpoint());
+                    System.out.println("Invalid endpoint URL: " + properties.getEndpoint());
                 }
             }
         }

--- a/src/main/java/ca/pjer/logback/compression/CompressionUtilility.java
+++ b/src/main/java/ca/pjer/logback/compression/CompressionUtilility.java
@@ -1,0 +1,29 @@
+package ca.pjer.logback.compression;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.zip.GZIPOutputStream;
+
+public final class CompressionUtilility {
+    public static byte[] compressGzip(byte[] bytes, int level) {
+        ByteArrayOutputStream obj = new ByteArrayOutputStream();
+        try (ConfigurableGZIPOutputStream gzip = new ConfigurableGZIPOutputStream(obj).withLevel(level)) {
+            gzip.write(bytes);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return obj.toByteArray();
+    }
+
+    private static class ConfigurableGZIPOutputStream extends GZIPOutputStream {
+        public ConfigurableGZIPOutputStream(OutputStream out) throws IOException {
+            super(out);
+        }
+
+        public ConfigurableGZIPOutputStream withLevel(int level) {
+            def.setLevel(level);
+            return this;
+        }
+    }
+}

--- a/src/main/java/ca/pjer/logback/metrics/AwsLogsMetricsHolder.java
+++ b/src/main/java/ca/pjer/logback/metrics/AwsLogsMetricsHolder.java
@@ -1,10 +1,10 @@
 package ca.pjer.logback.metrics;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class AwsLogsMetricsHolder {
     private static AwsLogsMetrics NULL = new AwsLogsMetrics() {
-
         @Override
         public void incrementLostCount() {
 
@@ -41,13 +41,25 @@ public class AwsLogsMetricsHolder {
         }
     };
 
-    private static AtomicReference<AwsLogsMetrics> INSTANCE = new AtomicReference<>(NULL);
+    public static AtomicReference<AwsLogsMetrics> INSTANCE = new AtomicReference<>(NULL);
+    public static AtomicBoolean DESIRED = new AtomicBoolean();
+
 
     public static AwsLogsMetrics get() {
         return INSTANCE.get();
     }
 
+    @SuppressWarnings("unused")
     public static void set(AwsLogsMetrics metrics) {
         INSTANCE.set(metrics);
+    }
+
+    public static void setDesired() {
+        DESIRED.set(true);
+    }
+
+    @SuppressWarnings("unused")
+    public static boolean isDesired() {
+        return DESIRED.get();
     }
 }

--- a/src/main/java/ca/pjer/logback/tokenisation/TokenUtility.java
+++ b/src/main/java/ca/pjer/logback/tokenisation/TokenUtility.java
@@ -1,0 +1,27 @@
+package ca.pjer.logback.tokenisation;
+
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TokenUtility {
+    public static String replaceTokens(String input, Map<String, Supplier<String>> tokenSuppliers) {
+        Pattern pattern = Pattern.compile("%\\{(.+?)}");
+        Matcher matcher = pattern.matcher(input);
+        StringBuffer buffer = new StringBuffer();
+
+        while (matcher.find()) {
+            Supplier<String> tokenSupplier = tokenSuppliers.get(matcher.group(1));
+            String replacement = "";
+
+            if (tokenSupplier != null) {
+                replacement = tokenSupplier.get();
+            }
+            matcher.appendReplacement(buffer, "");
+            buffer.append(replacement);
+        }
+        matcher.appendTail(buffer);
+        return buffer.toString();
+    }
+}


### PR DESCRIPTION
Hi @pierredavidbelanger,

We noticed that using CloudWatch logs is rather expensive and sought a way to reduce the cost.
One way we found is to use AWS S3 instead.

So the idea is apps will upload their logs to an AWS S3 bucket (after each flush time), and this S3 bucket will have event notification enabled to send ObjectCreated events to an AWS SQS queue when new log files are uploaded. 

A separate Filebeat service will watch the SQS queue and pick up these log files for shipping to ElasticSearch.

We expect to reduce our logging costs 10x by using this strategy, and still retaining all the same functionality we had before.

This PR adds support in the AWSLogs appender for uploading to S3 bucket.
All the concepts from CloudWatch (log groups, log streams, etc) are ported over to the S3 way so users can easily switch between the two if needed.

As example, we use the following logback and Filebeat configuration:

Logback.xml
```xml
<?xml version="1.0" encoding="UTF-8"?>
<configuration debug="false">
    <appender name="awslogs" class="ca.pjer.logback.AwsLogsAppender">
        <verbose>false</verbose>

        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
            <includeCallerData>true</includeCallerData>
        </encoder>
        <logGroupName>${MY_LOGGROUP}</logGroupName>
        <logStreamNamePattern>%{uuid}</logStreamNamePattern>
        <logRegion>${MY_REGION}</logRegion>
        <maxBatchLogEvents>10000</maxBatchLogEvents>
        <maxFlushTimeMillis>1000</maxFlushTimeMillis>
        <maxBlockTimeMillis>0</maxBlockTimeMillis>
        <retentionTimeDays>1</retentionTimeDays>

        <bucketName>${MY_BUCKET}</bucketName>
        <bucketPath>logs/log_stream_cluster=${MY_CLUSTER}/log_group=%{log_group}/date=%{date}/log_stream_container=${MY_APP}/log_stream=%{log_stream}/%{counter}.log</bucketPath>
        <logOutputType>s3</logOutputType>
        <verbose>true</verbose>
    </appender>

    <root level="INFO">
        <appender-ref ref="awslogs" />
    </root>
</configuration>
```

Filebeat:
```yml
filebeat.inputs:
- type: aws-s3
  queue_url: "${AWS_S3_QUEUE_URL}"
  content_type: application/json
  expand_event_list_from_field: Records

output.elasticsearch:
  hosts: '${ES_HOSTS}'
  allow_older_versions: true
  ssl.verification_mode: "none"
  username: "${FILEBEAT_USER}"
  password: "${FILEBEAT_PASS}"
  indices:
    - index: "myindex-%{+yyy.MM.dd}"
  compression_level: 5
  worker: 1
  max_retries: 3
  bulk_max_size: 500
  backoff.init: 1s
  backoff.max: 30s
  timeout: 10s

setup.template.enabled: false
setup.ilm.enabled: false

processors:
- decode_json_fields:
    when.regexp.message: '^{'
    fields: ["message"]
    target: ""
    overwrite_keys: true
- dissect:
    tokenizer: "logs/log_stream_cluster=%{log_stream_cluster}/log_group=%{log_group}/date=%{log_date}/log_stream_container=%{log_stream_container}/log_stream=%{log_stream_id}/%{log_filename_id}"
    field: "aws.s3.object.key"
    target_prefix: ""
    ignore_failure: true
    overwrite_keys: true
- drop_fields:
    fields: ["message_type", "agent", "ecs.version", "host.name", "owner", "subscription_filters", "aws.s3", "cloud", "input.type", "log.file.path", "log.offset", "log_filename_id", "log_date"]
    ignore_missing: true

logging.level: "${LOGGING_LEVEL}"
```
